### PR TITLE
Add/Update Options for Redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Don't include Vim and generic backup or temporary files
+.*.sw[a-z0-9]
+.sw[a-z0-9]
+*~
+
+# Ignore these Apple-specific directories
+.DS_Store
+.AppleDouble
+
+# Ignore any test-kitchen specific directories and temporary files
+.kitchen

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ redis_tcp_backlog: 511                # TCP backlog settings for connection
                                       # performance (may require sysctl updates)
 redis_timeout: 0                      # How long to wait before closing the
                                       # connection with the client
-
+redis_tcp_keepalive: 60               # Enable SO_KEEPALIVE and set how long the
+                                      # interval at which to send ACKs
 redis_log_level: notice               # Notice level for logs
 redis_log_file: "/var/log/redis/redis.log"  # Path to logs
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,15 @@ redis_daemonize: yes                  # Daemonize the service? Note: On systems
 redis_bind:                           # List of the IP addresses to pass onto
   - 127.0.0.1                         # bind (leave as empty array for all)
 redis_port: 6379                      # Port to bind to
-redis_tcp_backlog: 511                # TCP backlog settings for connection
-                                      # performance (may require sysctl updates)
-redis_timeout: 0                      # How long to wait before closing the
-                                      # connection with the client
+redis_tcp_backlog: 511                # [Optional] TCP backlog settings for
+                                      # connection performance (see NOTES)
+redis_timeout: 0                      # [Optional] Timeout for idle client
+                                      # connection (see NOTES)
 redis_tcp_keepalive: 60               # Enable SO_KEEPALIVE and set how long the
                                       # interval at which to send ACKs
+redis_socket: /run/redis/redis.sock   # [Optional] Path to create Unix Socket
+redis_socket_mode: 0755               # [Optional] Permission to give to Socket
+
 redis_log_level: notice               # Notice level for logs
 redis_log_file: "/var/log/redis/redis.log"  # Path to logs
 
@@ -54,6 +57,12 @@ redis_append_only: no                 # Enable append-only mode for data store
 redis_append_filename: appendonly.aof # Filename for append-only store
 redis_append_fsync: everysec          # When to fsync the data in the store
 ```
+
+### NOTES
+
+Both `redis_tcp_backlog` (i.e. `tcp-backlog`) and `redis_tcp_keepalive` (i.e.
+`tcp-keepalive`) options are relativly recent and may not be supported by all
+distributions and versions.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ redis_daemonize: yes                  # Daemonize the service? Note: On systems
 redis_bind:                           # List of the IP addresses to pass onto
   - 127.0.0.1                         # bind (leave as empty array for all)
 redis_port: 6379                      # Port to bind to
+redis_tcp_backlog: 511                # TCP backlog settings for connection
+                                      # performance (may require sysctl updates)
 redis_timeout: 60                     # Timeout
 
 redis_log_level: notice               # Notice level for logs

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ redis_bind:                           # List of the IP addresses to pass onto
 redis_port: 6379                      # Port to bind to
 redis_tcp_backlog: 511                # TCP backlog settings for connection
                                       # performance (may require sysctl updates)
-redis_timeout: 60                     # Timeout
+redis_timeout: 0                      # How long to wait before closing the
+                                      # connection with the client
 
 redis_log_level: notice               # Notice level for logs
 redis_log_file: "/var/log/redis/redis.log"  # Path to logs

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,8 +6,8 @@ redis_daemonize: yes
 redis_bind:
   - 127.0.0.1
 redis_port: 6379
-redis_tcp_backlog: 511
-redis_tcp_keepalive: 60
+# redis_tcp_backlog: 511
+# redis_tcp_keepalive: 60
 # redis_socket: "{{ redis_run_dir }}/{{ redis_service }}.sock"
 # redis_socket_mode: 0755
 redis_timeout: 0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ redis_daemonize: yes
 redis_bind:
   - 127.0.0.1
 redis_port: 6379
+redis_tcp_backlog: 511
 # redis_socket: "{{ redis_run_dir }}/{{ redis_service }}.sock"
 # redis_socket_mode: 0755
 redis_timeout: 60

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ redis_bind:
   - 127.0.0.1
 redis_port: 6379
 redis_tcp_backlog: 511
+redis_tcp_keepalive: 60
 # redis_socket: "{{ redis_run_dir }}/{{ redis_service }}.sock"
 # redis_socket_mode: 0755
 redis_timeout: 0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ redis_port: 6379
 redis_tcp_backlog: 511
 # redis_socket: "{{ redis_run_dir }}/{{ redis_service }}.sock"
 # redis_socket_mode: 0755
-redis_timeout: 60
+redis_timeout: 0
 # redis_auth: None
 
 # redis_role: master

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -14,6 +14,7 @@ unixsocketperm {{ redis_socket_mode }}
 {% endif %}
 
 timeout {{ redis_timeout }}
+tcp-keepalive {{ redis_tcp_keepalive }}
 
 loglevel {{ redis_log_level }}
 logfile {{ redis_log_file }}

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -5,6 +5,7 @@ pidfile {{ redis_run_dir }}/{{ redis_service }}.pid
 
 bind {{ redis_bind | join(' ') }}
 port {{ redis_port }}
+tcp-backlog {{ redis_tcp_backlog }}
 {% if redis_socket is defined %}
 unixsocket {{ redis_socket }}
 {%  if redis_unix_mode is defined %}

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -5,17 +5,21 @@ pidfile {{ redis_run_dir }}/{{ redis_service }}.pid
 
 bind {{ redis_bind | join(' ') }}
 port {{ redis_port }}
+{% if redis_tcp_backlog is defined %}
 tcp-backlog {{ redis_tcp_backlog }}
+{% endif %}
+{% if redis_tcp_keepalive is defined %}
+tcp-keepalive {{ redis_tcp_keepalive }}
+{% endif %}
+timeout {{ redis_timeout }}
+
 {% if redis_socket is defined %}
 unixsocket {{ redis_socket }}
 {%  if redis_unix_mode is defined %}
 unixsocketperm {{ redis_socket_mode }}
 {%  endif %}
+
 {% endif %}
-
-timeout {{ redis_timeout }}
-tcp-keepalive {{ redis_tcp_keepalive }}
-
 loglevel {{ redis_log_level }}
 logfile {{ redis_log_file }}
 

--- a/test/integration/redis/serverspec/redis_spec.rb
+++ b/test/integration/redis/serverspec/redis_spec.rb
@@ -36,7 +36,9 @@ describe file(config_file) do
   its(:content) { should match /^port 6379/ }
   its(:content) { should match /^unixsocket #{run_dir}\/redis.sock/ }
   its(:content) { should_not match /^unixsocketperm/ }
-  its(:content) { should match /^timeout 60/ }
+  its(:content) { should match /^timeout 0/ }
+  its(:content) { should match /^tcp-backlog 511/ }
+  its(:content) { should match /^tcp-keepalive 60/ }
   its(:content) { should match /^loglevel warning/ }
   its(:content) { should match /^logfile \/var\/log\/redis\/#{service_name}.log/ }
   its(:content) { should match /^syslog-enabled yes/ }

--- a/test/integration/redis/serverspec/redis_spec.rb
+++ b/test/integration/redis/serverspec/redis_spec.rb
@@ -37,8 +37,8 @@ describe file(config_file) do
   its(:content) { should match /^unixsocket #{run_dir}\/redis.sock/ }
   its(:content) { should_not match /^unixsocketperm/ }
   its(:content) { should match /^timeout 0/ }
-  its(:content) { should match /^tcp-backlog 511/ }
-  its(:content) { should match /^tcp-keepalive 60/ }
+  its(:content) { should_not match /^tcp-backlog/ }
+  its(:content) { should_not match /^tcp-keepalive/ }
   its(:content) { should match /^loglevel warning/ }
   its(:content) { should match /^logfile \/var\/log\/redis\/#{service_name}.log/ }
   its(:content) { should match /^syslog-enabled yes/ }


### PR DESCRIPTION
Add or update the `timeout`, `tcp-backlog`, and `tcp-keepalive` options in `redis.conf`.
