### PR TITLE
firewalld Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ redis_append_filename: appendonly.aof # Filename for append-only store
 redis_append_fsync: everysec          # When to fsync the data in the store
 ```
 
+Also:
+
+```yaml
+use_firewalld: no                     # If you use firewalld, enable this and
+                                      # the appropriate Firewall ports will be
+                                      # added and enabled in firewalld
+```
+
 ### NOTES
 
 Both `redis_tcp_backlog` (i.e. `tcp-backlog`) and `redis_tcp_keepalive` (i.e.

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -1,0 +1,11 @@
+---
+# firewall-specific tasks for redis
+
+- name: Open firewalld ports for Redis
+  firewalld:
+    port: "{{ redis_port }}/tcp"
+    permanent: true
+    state: enabled
+    immediate: yes
+  when:
+    (use_firewalld is defined and use_firewalld)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,4 +12,5 @@
     ansible_os_family == "Archlinux"
 
 - include: config.yml
+- include: firewall.yml
 - include: service.yml


### PR DESCRIPTION
Add support for the `use_firewalld` variable to allow Redis to open up firewalled ports using firewalld, if required.
