### PR TITLE
Enable firewalld and ufw support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ use_firewalld: no                     # If you use firewalld, enable this and
                                       # added and enabled in firewalld
 ```
 
+## Generic Variables
+
+These are generic variables which are common to many of the roles I produce:
+
+| Variable | Purpose | Default |
+| -------- | ------- | ------- |
+| `use_firewalld` | If set to `yes`, iptables rules will be opened up using `firewalld` | `Undefined` |
+| `use_ufw` | If set to `yes`, iptables rules will be opened up using `ufw` | `Undefined` |
+
 ### NOTES
 
 Both `redis_tcp_backlog` (i.e. `tcp-backlog`) and `redis_tcp_keepalive` (i.e.

--- a/README.md
+++ b/README.md
@@ -58,14 +58,6 @@ redis_append_filename: appendonly.aof # Filename for append-only store
 redis_append_fsync: everysec          # When to fsync the data in the store
 ```
 
-Also:
-
-```yaml
-use_firewalld: no                     # If you use firewalld, enable this and
-                                      # the appropriate Firewall ports will be
-                                      # added and enabled in firewalld
-```
-
 ## Generic Variables
 
 These are generic variables which are common to many of the roles I produce:

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -9,3 +9,12 @@
     immediate: yes
   when:
     (use_firewalld is defined and use_firewalld)
+
+- name: Open ufw ports for ElasticSearch
+  ufw:
+    port: "{{ redis_port }}"
+    proto: tcp
+    direction: in
+    policy: allow
+  when:
+    (use_ufw is defined and use_ufw)


### PR DESCRIPTION
Enable support for managing firewall rules through both UFW and firewalld services.
